### PR TITLE
Add public user profile pages and optimize with RPC

### DIFF
--- a/app/features/analytics/schema.ts
+++ b/app/features/analytics/schema.ts
@@ -1,0 +1,14 @@
+import { jsonb, pgEnum, pgTable, timestamp, uuid } from "drizzle-orm/pg-core";
+
+export const eventType = pgEnum("event_type", [
+  "applause_view",
+  "applause_visit",
+  "profile_view",
+]);
+
+export const events = pgTable("events", {
+  event_id: uuid("event_id").primaryKey().defaultRandom(),
+  event_type: eventType("event_type"),
+  event_data: jsonb("event_data"),
+  created_at: timestamp("created_at").defaultNow(),
+});

--- a/app/features/applauses/layouts/applause-overview-layout.tsx
+++ b/app/features/applauses/layouts/applause-overview-layout.tsx
@@ -1,5 +1,5 @@
 import { ChevronUpIcon, StarIcon } from "lucide-react";
-import { NavLink, Outlet } from "react-router";
+import { Link, NavLink, Outlet } from "react-router";
 import { Button, buttonVariants } from "~/common/components/ui/button";
 import { cn } from "~/lib/utils";
 import type { Route } from "./+types/applause-overview-layout";
@@ -18,10 +18,10 @@ export const loader = async ({ params }: Route.LoaderArgs) => {
 };
 
 export default function ApplauseOverviewLayout({
-  loaderData
+  loaderData,
 }: Route.ComponentProps) {
   return (
-   <div className="space-y-10">
+    <div className="space-y-10">
       <div className="flex justify-between">
         <div className="flex gap-10">
           <div className="size-40 rounded-xl shadow-xl bg-primary/50">
@@ -59,8 +59,11 @@ export default function ApplauseOverviewLayout({
             variant={"secondary"}
             size="lg"
             className="text-lg h-14 px-10"
+            asChild
           >
-            Visit Website
+            <Link to={`/applauses/${loaderData.applause.applause_id}/visit`}>
+              Visit Website
+            </Link>
           </Button>
           <Button size="lg" className="text-lg h-14 px-10">
             <ChevronUpIcon className="size-4" />
@@ -74,7 +77,7 @@ export default function ApplauseOverviewLayout({
           className={({ isActive }) =>
             cn(
               buttonVariants({ variant: "outline" }),
-              isActive && "bg-accent text-foreground "
+              isActive && "bg-accent text-foreground ",
             )
           }
           to={`/applauses/${loaderData.applause.applause_id}/overview`}
@@ -85,7 +88,7 @@ export default function ApplauseOverviewLayout({
           className={({ isActive }) =>
             cn(
               buttonVariants({ variant: "outline" }),
-              isActive && "bg-accent text-foreground "
+              isActive && "bg-accent text-foreground ",
             )
           }
           to={`/applauses/${loaderData.applause.applause_id}/praises`}
@@ -99,7 +102,7 @@ export default function ApplauseOverviewLayout({
             applause_id: loaderData.applause.applause_id,
             description: loaderData.applause.description,
             tagline: loaderData.applause.tagline,
-            praises_cnt: loaderData.applause.praises
+            praises_cnt: loaderData.applause.praises,
           }}
         />
       </div>

--- a/app/features/applauses/pages/applause-overview-page.tsx
+++ b/app/features/applauses/pages/applause-overview-page.tsx
@@ -2,8 +2,19 @@ import { ChevronUpIcon } from "lucide-react";
 import { Button } from "~/common/components/ui/button";
 import { Link, useOutletContext } from "react-router";
 import type { Route } from "./+types/applause-overview-page";
+import client from "~/supa-client";
 
-export default function ProductOverviewPage() {
+export const loader = async ({ params }: Route.LoaderArgs) => {
+  await client.rpc("track_event", {
+    event_type: "applause_view",
+    event_data: {
+      applause_id: params.applauseId,
+    },
+  });
+  return null;
+};
+
+export default function ApplauseOverviewPage() {
   const { description, tagline } = useOutletContext<{
     description: string;
     tagline: string;

--- a/app/features/applauses/pages/applause-praises-page.tsx
+++ b/app/features/applauses/pages/applause-praises-page.tsx
@@ -18,7 +18,7 @@ export const loader = async ({ params }: Route.LoaderArgs) => {
   return { praises };
 };
 
-export default function ProductPraisesPage({
+export default function ApplausePraisesPage({
   loaderData,
 }: Route.ComponentProps) {
   const { praise_count } = useOutletContext<{

--- a/app/features/applauses/pages/applause-visit-page.tsx
+++ b/app/features/applauses/pages/applause-visit-page.tsx
@@ -1,0 +1,20 @@
+import client from "~/supa-client";
+import { redirect } from "react-router";
+import type { Route } from "./+types/applause-visit-page";
+
+export const loader = async ({ params }: Route.LoaderArgs) => {
+  const { error, data } = await client
+    .from("applauses")
+    .select("url")
+    .eq("applause_id", Number(params.applauseId))
+    .single();
+  if (data) {
+    await client.rpc("track_event", {
+      event_type: "applause_visit",
+      event_data: {
+        applause_id: params.applauseId,
+      },
+    });
+    return redirect(data.url);
+  }
+};

--- a/app/features/applauses/queries.ts
+++ b/app/features/applauses/queries.ts
@@ -2,7 +2,7 @@ import { DateTime } from "luxon";
 import client from "~/supa-client";
 import { PAGE_SIZE } from "./constant";
 
-const applauseListSelect = `
+export const applauseListSelect = `
   applause_id,
   name,
   tagline,

--- a/app/features/users/layouts/dashboard-layout.tsx
+++ b/app/features/users/layouts/dashboard-layout.tsx
@@ -44,13 +44,13 @@ export default function DashboardLayout() {
             </SidebarMenu>
           </SidebarGroup>
           <SidebarGroup>
-            <SidebarGroupLabel>Product Analytics</SidebarGroupLabel>
+            <SidebarGroupLabel>Applause Analytics</SidebarGroupLabel>
             <SidebarMenu>
               <SidebarMenuItem>
                 <SidebarMenuButton asChild>
                   <Link to="/my/dashboard/applauses/1">
                     <RocketIcon className="size-4" />
-                    <span>Product 1</span>
+                    <span>Applause 1</span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>

--- a/app/features/users/layouts/profile-layout.tsx
+++ b/app/features/users/layouts/profile-layout.tsx
@@ -16,24 +16,32 @@ import {
   DialogTrigger,
 } from "~/common/components/ui/dialog";
 import { Textarea } from "~/common/components/ui/textarea";
+import type { Route } from "./+types/profile-layout";
+import { getUserProfile } from "../queries";
 
-export default function ProfileLayout() {
-  const { username } = useParams();
-  const profileUrl = `/users/${username}`;
-  const displayName = username ?? "member";
+export const loader = async ({
+  params,
+}: Route.LoaderArgs ) => {
+  const user = await getUserProfile(params.username);
+  return { user };
+};
 
+export default function ProfileLayout({ loaderData }: Route.ComponentProps) {
   return (
     <div className="space-y-10">
       <div className="flex flex-col gap-6 lg:flex-row lg:items-center">
         <Avatar className="size-24 sm:size-32 lg:size-40">
-          <AvatarImage src="https://github.com/shadcn.png" />
-          <AvatarFallback>
-            {displayName.slice(0, 2).toUpperCase()}
-          </AvatarFallback>
+          {loaderData.user.avatar ? (
+            <AvatarImage src={loaderData.user.avatar} />
+          ) : (
+            <AvatarFallback className="text-2xl">
+              {loaderData.user.name[0]}
+            </AvatarFallback>
+          )}
         </Avatar>
         <div className="space-y-5">
           <div className="flex flex-wrap gap-2">
-            <h1 className="text-2xl font-semibold">@{displayName}</h1>
+       <h1 className="text-2xl font-semibold">{loaderData.user.name}</h1>
             <Button variant="outline" asChild>
               <Link to="/my/settings">Edit profile</Link>
             </Button>
@@ -48,7 +56,7 @@ export default function ProfileLayout() {
                 </DialogHeader>
                 <DialogDescription className="space-y-4">
                   <span className="text-sm text-muted-foreground">
-                    Send a check-in message to @{displayName}
+                    Send a check-in message to @{loaderData.user.name}
                   </span>
                   <Form className="space-y-4">
                     <Textarea
@@ -63,10 +71,12 @@ export default function ProfileLayout() {
             </Dialog>
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            <span className="text-sm text-muted-foreground">
-              @{displayName}
+         <span className="text-sm text-muted-foreground">
+              @{loaderData.user.username}
             </span>
-            <Badge variant={"secondary"}>Habit Builder</Badge>
+            <Badge variant={"secondary"} className="capitalize">
+              {loaderData.user.role}
+            </Badge>
             <Badge variant={"secondary"}>100 followers</Badge>
             <Badge variant={"secondary"}>100 following</Badge>
           </div>
@@ -74,9 +84,12 @@ export default function ProfileLayout() {
       </div>
       <div className="flex flex-wrap gap-3">
         {[
-          { label: "About", to: profileUrl },
-          { label: "Actions", to: `${profileUrl}/applauses` },
-          { label: "Posts", to: `${profileUrl}/posts` },
+          { label: "About", to: `/users/${loaderData.user.username}` },
+          {
+            label: "Applauses",
+            to: `/users/${loaderData.user.username}/applauses`,
+          },
+          { label: "Posts", to: `/users/${loaderData.user.username}/posts` },
         ].map((item) => (
           <NavLink
             end
@@ -93,8 +106,13 @@ export default function ProfileLayout() {
           </NavLink>
         ))}
       </div>
-      <div className="max-w-screen-md">
-        <Outlet />
+      <div className="max-w-3xl">
+          <Outlet
+          context={{
+            headline: loaderData.user.headline,
+            bio: loaderData.user.bio,
+          }}
+        />
       </div>
     </div>
   );

--- a/app/features/users/layouts/profile-layout.tsx
+++ b/app/features/users/layouts/profile-layout.tsx
@@ -19,6 +19,11 @@ import { Textarea } from "~/common/components/ui/textarea";
 import type { Route } from "./+types/profile-layout";
 import { getUserProfile } from "../queries";
 
+export const meta: Route.MetaFunction = ({ params }) => {
+  return [{ title: `${params.username}'s Profile | app_lause` }];
+};
+
+
 export const loader = async ({
   params,
 }: Route.LoaderArgs ) => {

--- a/app/features/users/pages/profile-applauses-page.tsx
+++ b/app/features/users/pages/profile-applauses-page.tsx
@@ -1,13 +1,6 @@
 import { ApplauseCard } from "~/features/applauses/components/applause-card";
 import type { Route } from "./+types/profile-applauses-page";
-
-export function loader({ params }: Route.LoaderArgs) {
-  return { username: params.username };
-}
-
-export function action(_args: Route.ActionArgs) {
-  return {};
-}
+import { getUserApplauses } from "../queries";
 
 export const meta: Route.MetaFunction = ({ params }) => {
   return [
@@ -18,19 +11,25 @@ export const meta: Route.MetaFunction = ({ params }) => {
     },
   ];
 };
+export const loader = async ({ params }: Route.LoaderArgs) => {
+  const applauses = await getUserApplauses(params.username);
+  return { applauses };
+};
 
-export default function ProfileApplausesPage() {
+export default function ProfileApplausesPage({
+  loaderData,
+}: Route.ComponentProps) {
   return (
     <div className="flex flex-col gap-5">
-      {Array.from({ length: 5 }).map((_, index) => (
+{loaderData.applauses.map((applause) => (
         <ApplauseCard
-          key={`growth-action-${index}`}
-          id={`growth-action-${index}`}
-          title="Kept a morning reflection streak for 7 days"
-          description="A small routine that helped create more focus, awareness, and momentum."
-          commentsCount={12}
-          viewsCount={12}
-          applauseCount={120}
+          key={applause.applause_id}
+          id={applause.applause_id}
+          name={applause.name}
+          description={applause.tagline}
+          praisesCount={applause.praises}
+          viewsCount={applause.views}
+          votesCount={applause.upvotes}
         />
       ))}
     </div>

--- a/app/features/users/pages/profile-applauses-page.tsx
+++ b/app/features/users/pages/profile-applauses-page.tsx
@@ -2,15 +2,6 @@ import { ApplauseCard } from "~/features/applauses/components/applause-card";
 import type { Route } from "./+types/profile-applauses-page";
 import { getUserApplauses } from "../queries";
 
-export const meta: Route.MetaFunction = ({ params }) => {
-  return [
-    { title: `${params.username}'s Applauses | app_lause` },
-    {
-      name: "description",
-      content: "View self-growth actions recognized by this user",
-    },
-  ];
-};
 export const loader = async ({ params }: Route.LoaderArgs) => {
   const applauses = await getUserApplauses(params.username);
   return { applauses };

--- a/app/features/users/pages/profile-page.tsx
+++ b/app/features/users/pages/profile-page.tsx
@@ -1,35 +1,24 @@
+import { useOutletContext } from "react-router";
 import type { Route } from "./+types/profile-page";
 
 export const meta: Route.MetaFunction = ({ params }) => {
-  return [
-    { title: `${params.username}'s Profile | app_lause` },
-  ];
+  return [{ title: `${params.username}'s Profile | app_lause` }];
 };
 
-export function loader({ params }: Route.LoaderArgs) {
-  return { username: params.username };
-}
-
-export function action(_args: Route.ActionArgs) {
-  return {};
-}
-
-export default function ProfilePage({ loaderData }: Route.ComponentProps) {
+export default function ProfilePage() {
+  const { headline, bio } = useOutletContext<{
+    headline: string;
+    bio: string;
+  }>();
   return (
-    <div className="max-w-screen-md flex flex-col space-y-10">
+    <div className="max-w-3xl flex flex-col space-y-10">
       <div className="space-y-2">
         <h4 className="text-lg font-bold">Headline</h4>
-        <p className="text-muted-foreground">
-          @{loaderData.username} is building better routines through small,
-          consistent actions and weekly reflection.
-        </p>
+        <p className="text-muted-foreground">{headline}</p>
       </div>
       <div className="space-y-2">
-        <h4 className="text-lg font-bold">About</h4>
-        <p className="text-muted-foreground">
-          Focused on self-growth, accountability, and turning everyday progress
-          into habits that last.
-        </p>
+        <h4 className="text-lg font-bold">Bio</h4>
+        <p className="text-muted-foreground">{bio}</p>
       </div>
     </div>
   );

--- a/app/features/users/pages/profile-page.tsx
+++ b/app/features/users/pages/profile-page.tsx
@@ -1,5 +1,17 @@
 import { useOutletContext } from "react-router";
 import type { Route } from "./+types/profile-page";
+import client from "~/supa-client";
+
+
+export const loader = async ({ params }: Route.LoaderArgs) => {
+  await client.rpc("track_event", {
+    event_type: "profile_view",
+    event_data: {
+      username: params.username,
+    },
+  });
+  return null;
+};
 
 export default function ProfilePage() {
   const { headline, bio } = useOutletContext<{

--- a/app/features/users/pages/profile-page.tsx
+++ b/app/features/users/pages/profile-page.tsx
@@ -1,10 +1,6 @@
 import { useOutletContext } from "react-router";
 import type { Route } from "./+types/profile-page";
 
-export const meta: Route.MetaFunction = ({ params }) => {
-  return [{ title: `${params.username}'s Profile | app_lause` }];
-};
-
 export default function ProfilePage() {
   const { headline, bio } = useOutletContext<{
     headline: string;

--- a/app/features/users/pages/profile-posts-page.tsx
+++ b/app/features/users/pages/profile-posts-page.tsx
@@ -1,36 +1,24 @@
 import { PostCard } from "~/features/community/components/post-card";
 import type { Route } from "./+types/profile-posts-page";
+import { getUserPosts } from "../queries";
 
-export function loader({ params }: Route.LoaderArgs) {
-  return { username: params.username };
-}
-
-export function action(_args: Route.ActionArgs) {
-  return {};
-}
-
-export const meta: Route.MetaFunction = ({ params }) => {
-  return [
-    { title: `${params.username}'s Posts | app_lause` },
-    {
-      name: "description",
-      content: "View reflections and posts from this user",
-    },
-  ];
+export const loader = async ({ params }: Route.LoaderArgs) => {
+  const posts = await getUserPosts(params.username);
+  return { posts };
 };
 
 export default function ProfilePostsPage({ loaderData }: Route.ComponentProps) {
   return (
     <div className="flex flex-col gap-5">
-      {Array.from({ length: 5 }).map((_, index) => (
+      {loaderData.posts.map((post) => (
         <PostCard
-          key={`postId-${index}`}
-          id={`postId-${index}`}
-          title="What I learned from tracking one habit for a week"
-          author={loaderData.username ?? "Nico"}
-          avatarSrc="https://github.com/apple.png"
-          category="Reflection"
-          postedAt="12 hours ago"
+          key={post.post_id}
+          id={post.post_id}
+          title={post.title}
+          author={post.author}
+          avatarSrc={post.author_avatar}
+          category={post.topic}
+          postedAt={post.created_at}
           expanded
         />
       ))}

--- a/app/features/users/queries.ts
+++ b/app/features/users/queries.ts
@@ -1,57 +1,56 @@
-// import db from "~/db";
-// import { posts, postUpvotes, topics } from "./schema";
-// import { asc, count, desc, eq } from "drizzle-orm";
-// import { profiles } from "../users/schema";
-
 import client from "~/supa-client";
+import { features } from "process";
+import { applauseListSelect } from "../applauses/queries";
 
-// export const getTopics = async () => {
-//   const allTopics = await db
-//     .select({
-//       name: topics.name,
-//       slug: topics.slug,
-//     })
-//     .from(topics);
-//   return allTopics;
-// };
-
-// export const getPosts = async () => {
-//   const allPosts = await db
-//     .select({
-//       id: posts.post_id,
-//       title: posts.title,
-//       createdAt: posts.created_at,
-//       topic: topics.name,
-//       author: profiles.name,
-//       authorAvatarUrl: profiles.avatar,
-//       username: profiles.username,
-//       upvotes: count(postUpvotes.post_id),
-//     })
-//     .from(posts)
-//     .innerJoin(topics, eq(posts.topic_id, topics.topic_id))
-//     .innerJoin(profiles, eq(posts.profile_id, profiles.profile_id))
-//     .leftJoin(postUpvotes, eq(posts.post_id, postUpvotes.post_id))
-//     .groupBy(
-//       posts.post_id,
-//       profiles.name,
-//       profiles.avatar,
-//       profiles.username,
-//       topics.name
-//     )
-//     .orderBy(asc(posts.post_id));
-//   return allPosts;
-// };
-
-export const getTopics = async () => {
-  const { data, error } = await client.from("topics").select("name, slug");
-  if (error) throw new Error(error.message);
+export const getUserProfile = async (username: string) => {
+  const { data, error } = await client
+    .from("profiles")
+    .select(
+      `
+        profile_id,
+        name,
+        username,
+        avatar,
+        role,
+        headline,
+        bio
+        `,
+    )
+    .eq("username", username)
+    .single();
+  if (error) {
+    throw error;
+  }
   return data;
 };
 
-export const getPosts = async () => {
+export const getUserApplauses = async (username: string) => {
   const { data, error } = await client
-    .from("community_post_list_view")
-    .select(`*`);
-  if (error) throw new Error(error.message);
+    .from("applauses")
+    .select(
+      `
+        ${applauseListSelect},profiles!applauses_profile_id_profiles_profile_id_fk!inner(profile_id)
+    `,
+    )
+    .eq("profiles.username", username);
+  if (error) {
+    throw error;
+  }
+  return data;
+};
+
+export const getUserPosts = async (username: string) => {
+  const { data, error } = await client
+    .from("posts")
+    .select(
+      `
+*,
+author:profile_id!inner(username)
+`,
+    )
+    .eq("profile_id.username", username);
+  if (error) {
+    throw error;
+  }
   return data;
 };

--- a/app/features/users/queries.ts
+++ b/app/features/users/queries.ts
@@ -41,14 +41,9 @@ export const getUserApplauses = async (username: string) => {
 
 export const getUserPosts = async (username: string) => {
   const { data, error } = await client
-    .from("posts")
-    .select(
-      `
-*,
-author:profile_id!inner(username)
-`,
-    )
-    .eq("profile_id.username", username);
+    .from("community_post_list_view")
+    .select("*")
+    .eq("author_username", username);
   if (error) {
     throw error;
   }

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -109,8 +109,8 @@ export default [
     route("settings", "features/users/pages/settings-page.tsx"),
     route("notifications", "features/users/pages/notifications-page.tsx"),
   ]),
-  layout("features/users/layouts/profile-layout.tsx", [
-    ...prefix("users/:username", [
+  ...prefix("users/:username", [
+    layout("features/users/layouts/profile-layout.tsx", [
       index("features/users/pages/profile-page.tsx"),
       route("applauses", "features/users/pages/profile-applauses-page.tsx"),
       route("posts", "features/users/pages/profile-posts-page.tsx"),

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -53,6 +53,7 @@ export default [
           index("features/applauses/pages/applause-praises-page.tsx"),
         ]),
       ]),
+      route("visit", "features/applauses/pages/applause-visit-page.tsx"),
     ]),
   ]),
   ...prefix("ideas", [

--- a/app/sql/functions/track_event.sql
+++ b/app/sql/functions/track_event.sql
@@ -1,0 +1,40 @@
+create or replace function track_event(
+    event_type event_type,
+    event_data jsonb
+) returns void as $$
+declare
+    username_var text;
+    found_profile_id uuid;
+    found_applause_id bigint;
+    new_event_data jsonb;
+    safe_applause_id bigint;
+begin
+    if event_type = 'profile_view' then
+        username_var := event_data->>'username';
+        if username_var is not null then
+            select profile_id into found_profile_id from public.profiles where username = username_var;
+            if found_profile_id is not null then
+                new_event_data := event_data - 'username';
+                new_event_data := jsonb_set(new_event_data, '{profile_id}', to_jsonb(found_profile_id));
+                insert into events (event_type, event_data)
+                values (event_type, new_event_data);
+            end if;
+        end if;
+    elsif event_type = 'applause_view' or event_type = 'applause_visit' then
+        if (event_data ? 'applause_id') then
+            begin
+                safe_applause_id := (event_data->>'applause_id')::bigint;
+            exception when others then
+                safe_applause_id := null;
+            end;
+            if safe_applause_id is not null then
+                select applause_id into found_applause_id from public.applauses where applause_id = safe_applause_id;
+                if found_applause_id is not null then
+                    insert into events (event_type, event_data)
+                    values (event_type, event_data);
+                end if;
+            end if;
+        end if;
+    end if;
+end;
+$$ language plpgsql;

--- a/app/sql/migrations/0002_sleepy_odin.sql
+++ b/app/sql/migrations/0002_sleepy_odin.sql
@@ -1,0 +1,7 @@
+CREATE TYPE "public"."event_type" AS ENUM('applause_view', 'applause_visit', 'profile_view');--> statement-breakpoint
+CREATE TABLE "events" (
+	"event_id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_type" "event_type",
+	"event_data" jsonb,
+	"created_at" timestamp DEFAULT now()
+);

--- a/app/sql/migrations/meta/0002_snapshot.json
+++ b/app/sql/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1679 @@
+{
+  "id": "5435bb65-6bb2-48bc-abff-abe777d58cba",
+  "prevId": "d4be9dc0-0c69-4bb1-9051-0114779901b9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applause_upvotes": {
+      "name": "applause_upvotes",
+      "schema": "",
+      "columns": {
+        "applause_id": {
+          "name": "applause_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "applause_upvotes_applause_id_applauses_applause_id_fk": {
+          "name": "applause_upvotes_applause_id_applauses_applause_id_fk",
+          "tableFrom": "applause_upvotes",
+          "tableTo": "applauses",
+          "columnsFrom": [
+            "applause_id"
+          ],
+          "columnsTo": [
+            "applause_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applause_upvotes_profile_id_profiles_profile_id_fk": {
+          "name": "applause_upvotes_profile_id_profiles_profile_id_fk",
+          "tableFrom": "applause_upvotes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "applause_upvotes_applause_id_profile_id_pk": {
+          "name": "applause_upvotes_applause_id_profile_id_pk",
+          "columns": [
+            "applause_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applauses": {
+      "name": "applauses",
+      "schema": "",
+      "columns": {
+        "applause_id": {
+          "name": "applause_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "applauses_applause_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"views\":0,\"praises\":0,\"upvotes\":0}'::jsonb"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "applauses_profile_id_profiles_profile_id_fk": {
+          "name": "applauses_profile_id_profiles_profile_id_fk",
+          "tableFrom": "applauses",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applauses_category_id_categories_category_id_fk": {
+          "name": "applauses_category_id_categories_category_id_fk",
+          "tableFrom": "applauses",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "category_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "category_id": {
+          "name": "category_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "categories_category_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "value": {
+          "name": "value",
+          "type": "applause_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.praises": {
+      "name": "praises",
+      "schema": "",
+      "columns": {
+        "praise_id": {
+          "name": "praise_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "praises_praise_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "applause_id": {
+          "name": "applause_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "praises_applause_id_applauses_applause_id_fk": {
+          "name": "praises_applause_id_applauses_applause_id_fk",
+          "tableFrom": "praises",
+          "tableTo": "applauses",
+          "columnsFrom": [
+            "applause_id"
+          ],
+          "columnsTo": [
+            "applause_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "praises_profile_id_profiles_profile_id_fk": {
+          "name": "praises_profile_id_profiles_profile_id_fk",
+          "tableFrom": "praises",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "rating_check": {
+          "name": "rating_check",
+          "value": "\"praises\".\"rating\" BETWEEN 1 AND 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "challenges_challenge_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overview": {
+          "name": "overview",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal": {
+          "name": "goal",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benefits": {
+          "name": "benefits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_name": {
+          "name": "host_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge_type": {
+          "name": "challenge_type",
+          "type": "challenge_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participation_type": {
+          "name": "participation_type",
+          "type": "challenge_participation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "challenge_duration",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views_count": {
+          "name": "views_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_replies": {
+      "name": "post_replies",
+      "schema": "",
+      "columns": {
+        "post_reply_id": {
+          "name": "post_reply_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "post_replies_post_reply_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_replies_post_id_posts_post_id_fk": {
+          "name": "post_replies_post_id_posts_post_id_fk",
+          "tableFrom": "post_replies",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_replies_parent_id_post_replies_post_reply_id_fk": {
+          "name": "post_replies_parent_id_post_replies_post_reply_id_fk",
+          "tableFrom": "post_replies",
+          "tableTo": "post_replies",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "post_reply_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_replies_profile_id_profiles_profile_id_fk": {
+          "name": "post_replies_profile_id_profiles_profile_id_fk",
+          "tableFrom": "post_replies",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_upvotes": {
+      "name": "post_upvotes",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_upvotes_post_id_posts_post_id_fk": {
+          "name": "post_upvotes_post_id_posts_post_id_fk",
+          "tableFrom": "post_upvotes",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "post_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_upvotes_profile_id_profiles_profile_id_fk": {
+          "name": "post_upvotes_profile_id_profiles_profile_id_fk",
+          "tableFrom": "post_upvotes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_upvotes_post_id_profile_id_pk": {
+          "name": "post_upvotes_post_id_profile_id_pk",
+          "columns": [
+            "post_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "posts_post_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_topic_id_topics_topic_id_fk": {
+          "name": "posts_topic_id_topics_topic_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "topic_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_profile_id_profiles_profile_id_fk": {
+          "name": "posts_profile_id_profiles_profile_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "topic_id": {
+          "name": "topic_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "topics_topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "value": {
+          "name": "value",
+          "type": "community_topic",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idea_likes": {
+      "name": "idea_likes",
+      "schema": "",
+      "columns": {
+        "idea_id": {
+          "name": "idea_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "idea_likes_idea_id_ideas_idea_id_fk": {
+          "name": "idea_likes_idea_id_ideas_idea_id_fk",
+          "tableFrom": "idea_likes",
+          "tableTo": "ideas",
+          "columnsFrom": [
+            "idea_id"
+          ],
+          "columnsTo": [
+            "idea_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "idea_likes_profile_id_profiles_profile_id_fk": {
+          "name": "idea_likes_profile_id_profiles_profile_id_fk",
+          "tableFrom": "idea_likes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idea_likes_idea_id_profile_id_pk": {
+          "name": "idea_likes_idea_id_profile_id_pk",
+          "columns": [
+            "idea_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ideas": {
+      "name": "ideas",
+      "schema": "",
+      "columns": {
+        "idea_id": {
+          "name": "idea_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "ideas_idea_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "views_count": {
+          "name": "views_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ideas_claimed_by_profiles_profile_id_fk": {
+          "name": "ideas_claimed_by_profiles_profile_id_fk",
+          "tableFrom": "ideas",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "claimed_by"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "teams_team_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "team_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "open_spots": {
+          "name": "open_spots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles": {
+          "name": "roles",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leader_profile_id": {
+          "name": "leader_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_leader_profile_id_profiles_profile_id_fk": {
+          "name": "teams_leader_profile_id_profiles_profile_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "leader_profile_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_name_check": {
+          "name": "team_name_check",
+          "value": "LENGTH(\"teams\".\"name\") <= 20"
+        },
+        "team_size_check": {
+          "name": "team_size_check",
+          "value": "\"teams\".\"size\" BETWEEN 1 AND 100"
+        },
+        "open_spots_check": {
+          "name": "open_spots_check",
+          "value": "\"teams\".\"open_spots\" BETWEEN 1 AND 100"
+        },
+        "team_description_check": {
+          "name": "team_description_check",
+          "value": "LENGTH(\"teams\".\"description\") <= 200"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_follower_id_profiles_profile_id_fk": {
+          "name": "follows_follower_id_profiles_profile_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_profiles_profile_id_fk": {
+          "name": "follows_following_id_profiles_profile_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_room_members": {
+      "name": "message_room_members",
+      "schema": "",
+      "columns": {
+        "message_room_id": {
+          "name": "message_room_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "message_room_members_message_room_id_message_rooms_message_room_id_fk": {
+          "name": "message_room_members_message_room_id_message_rooms_message_room_id_fk",
+          "tableFrom": "message_room_members",
+          "tableTo": "message_rooms",
+          "columnsFrom": [
+            "message_room_id"
+          ],
+          "columnsTo": [
+            "message_room_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_room_members_profile_id_profiles_profile_id_fk": {
+          "name": "message_room_members_profile_id_profiles_profile_id_fk",
+          "tableFrom": "message_room_members",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "message_room_members_message_room_id_profile_id_pk": {
+          "name": "message_room_members_message_room_id_profile_id_pk",
+          "columns": [
+            "message_room_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_rooms": {
+      "name": "message_rooms",
+      "schema": "",
+      "columns": {
+        "message_room_id": {
+          "name": "message_room_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "message_rooms_message_room_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "messages_message_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "message_room_id": {
+          "name": "message_room_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_seen": {
+          "name": "is_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_message_room_id_message_rooms_message_room_id_fk": {
+          "name": "messages_message_room_id_message_rooms_message_room_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "message_rooms",
+          "columnsFrom": [
+            "message_room_id"
+          ],
+          "columnsTo": [
+            "message_room_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_sender_id_profiles_profile_id_fk": {
+          "name": "messages_sender_id_profiles_profile_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "notification_id": {
+          "name": "notification_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notifications_notification_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applause_id": {
+          "name": "applause_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_source_id_profiles_profile_id_fk": {
+          "name": "notifications_source_id_profiles_profile_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_target_id_profiles_profile_id_fk": {
+          "name": "notifications_target_id_profiles_profile_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'habit-builder'"
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "views": {
+          "name": "views",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_profile_id_users_id_fk": {
+          "name": "profiles_profile_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "applause_view",
+        "applause_visit",
+        "profile_view"
+      ]
+    },
+    "public.applause_category": {
+      "name": "applause_category",
+      "schema": "public",
+      "values": [
+        "mindset",
+        "wellness",
+        "focus",
+        "routine",
+        "reflection",
+        "learning",
+        "creativity",
+        "relationships",
+        "energy"
+      ]
+    },
+    "public.challenge_duration": {
+      "name": "challenge_duration",
+      "schema": "public",
+      "values": [
+        "1 - 3 days",
+        "4 - 7 days",
+        "1 - 2 weeks",
+        "2 - 4 weeks",
+        "1 - 2 months",
+        "2 months+"
+      ]
+    },
+    "public.challenge_participation_type": {
+      "name": "challenge_participation_type",
+      "schema": "public",
+      "values": [
+        "solo",
+        "pair",
+        "group"
+      ]
+    },
+    "public.challenge_type": {
+      "name": "challenge_type",
+      "schema": "public",
+      "values": [
+        "mindset",
+        "wellness",
+        "focus"
+      ]
+    },
+    "public.community_topic": {
+      "name": "community_topic",
+      "schema": "public",
+      "values": [
+        "self-growth",
+        "wellness",
+        "mindset",
+        "routine",
+        "reflection"
+      ]
+    },
+    "public.team_stage": {
+      "name": "team_stage",
+      "schema": "public",
+      "values": [
+        "starting",
+        "first-members",
+        "active",
+        "expanding"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "follow",
+        "praise",
+        "reply",
+        "mention"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "habit-builder",
+        "mindful-learner",
+        "accountability-partner",
+        "growth-coach",
+        "reflective-writer",
+        "other"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/sql/migrations/meta/_journal.json
+++ b/app/sql/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777535420684,
       "tag": "0001_far_jasper_sitwell",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1778497124396,
+      "tag": "0002_sleepy_odin",
+      "breakpoints": true
     }
   ]
 }

--- a/database.types.ts
+++ b/database.types.ts
@@ -213,6 +213,27 @@ export type Database = {
         }
         Relationships: []
       }
+      events: {
+        Row: {
+          created_at: string | null
+          event_data: Json | null
+          event_id: string
+          event_type: Database["public"]["Enums"]["event_type"] | null
+        }
+        Insert: {
+          created_at?: string | null
+          event_data?: Json | null
+          event_id?: string
+          event_type?: Database["public"]["Enums"]["event_type"] | null
+        }
+        Update: {
+          created_at?: string | null
+          event_data?: Json | null
+          event_id?: string
+          event_type?: Database["public"]["Enums"]["event_type"] | null
+        }
+        Relationships: []
+      }
       follows: {
         Row: {
           created_at: string
@@ -855,7 +876,13 @@ export type Database = {
       }
     }
     Functions: {
-      [_ in never]: never
+      track_event: {
+        Args: {
+          event_data: Json
+          event_type: Database["public"]["Enums"]["event_type"]
+        }
+        Returns: undefined
+      }
     }
     Enums: {
       applause_category:
@@ -883,6 +910,7 @@ export type Database = {
         | "mindset"
         | "routine"
         | "reflection"
+      event_type: "applause_view" | "applause_visit" | "profile_view"
       notification_type: "follow" | "praise" | "reply" | "mention"
       role:
         | "habit-builder"
@@ -1047,6 +1075,7 @@ export const Constants = {
         "routine",
         "reflection",
       ],
+      event_type: ["applause_view", "applause_visit", "profile_view"],
       notification_type: ["follow", "praise", "reply", "mention"],
       role: [
         "habit-builder",

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -7,9 +7,5 @@ export default defineConfig({
   dbCredentials: {
     url: process.env.DATABASE_URL!,
   },
-  migrations: {
-  table: "__drizzle_migrations",
-  schema: "public",
-},
 });
 


### PR DESCRIPTION
Closes #42 

## Summary
- Added public user profile page
- Displayed user posts list
- Connected navigation between profile and posts
- Move repeated or complex query logic into RPCs

## Self-review
- [ ] Verified profile page renders correctly
- [ ] Checked user posts list rendering
- [ ] Confirmed navigation between profile and posts
- [ ] Ensured UI consistency with other pages
- [ ] Reviewed route params handling
- [ ] RPC functions are added where needed

## Review notes
- Check empty state when user has no posts
- Verify route params safety before rendering profile
- Consider extracting reusable profile components